### PR TITLE
Add influx db support

### DIFF
--- a/include/config.h.template
+++ b/include/config.h.template
@@ -7,8 +7,8 @@
 
 #define WIFI_SSID "enter SSID here"
 #define WIFI_PW "wifi pw here"
-#define LOADCELL_DOUT_PIN = 16;
-#define LOADCELL_SCK_PIN = 4;
+#define LOADCELL_DOUT_PIN 16
+#define LOADCELL_SCK_PIN 4
 //REPLACE WITH YOUR CALIBRATION FACTOR
 #define CALIBRATION_FACTOR 43374.00
 #define BUTTON_PIN 0

--- a/include/config.h.template
+++ b/include/config.h.template
@@ -1,6 +1,10 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#define DEVICE_NAME "My_Sensor_Device"
+#define TZ "PST8PDT"
+
+
 #define WIFI_SSID "enter SSID here"
 #define WIFI_PW "wifi pw here"
 #define LOADCELL_DOUT_PIN = 16;

--- a/include/config.h.template
+++ b/include/config.h.template
@@ -7,5 +7,15 @@
 #define LOADCELL_SCK_PIN = 4;
 //REPLACE WITH YOUR CALIBRATION FACTOR
 #define CALIBRATION_FACTOR 43374.00
+#define BUTTON_PIN 0
+
+//InfluxDB Configuration
+#define INFLUXDB_URL "influxdb-url"
+// InfluxDB 2 server or cloud API authentication token (Use: InfluxDB UI -> Load Data -> Tokens -> <select token>)
+#define INFLUXDB_TOKEN "toked-id"
+// InfluxDB 2 organization id (Use: InfluxDB UI -> Settings -> Profile -> <name under tile> )
+#define INFLUXDB_ORG "org"
+// InfluxDB 2 bucket name (Use: InfluxDB UI -> Load Data -> Buckets)
+#define INFLUXDB_BUCKET "bucket"
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,5 +17,6 @@ lib_deps =
 	pololu/Pushbutton@^2.0.0
 	adafruit/Adafruit GFX Library@^1.11.2
 	adafruit/Adafruit SSD1306@^2.5.4
+	tobiasschuerg/ESP8266 Influxdb@^3.12.0
 upload_port = /dev/cu.usbserial-0001
 monitor_speed = 115200

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,6 +108,12 @@ void setup() {
 
 void loop() {
   // If no Wifi signal, try to reconnect it
+
+  if (button.getSingleDebouncedPress()){
+    Serial.println("Tare reset to 0");
+    scale.tare();
+  }
+  
   if (wifiMulti.run() != WL_CONNECTED) {
     Serial.println("Wifi connection lost");
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,7 @@ void loop() {
   }
   
   if (scale.wait_ready_timeout(200)) {
-    reading = round(scale.get_units());
+    reading = (scale.get_units());
     Serial.print("Weight: ");
     Serial.println(reading);
     if (reading != lastReading){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,8 @@ WiFiMulti wifiMulti;
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include <Pushbutton.h>
+#include <InfluxDbClient.h>
+
 
 #include <config.h> 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,8 +34,6 @@ Point sensor("force_gauge");
 #define OLED_RESET     -1 // Reset pin # (or -1 if sharing Arduino reset pin)
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
-Pushbutton button(BUTTON_PIN);
-
 void displayWeight(float weight){
   display.clearDisplay();
   display.setTextSize(1);
@@ -84,7 +82,7 @@ void setup() {
     }
 
   // Add constant tags - only once
-  sensor.addTag("device", DEVICE_NAME);
+  sensor.addTag("device", DEVICE_NAME + WiFi.macAddress());
 
   // Check server connection
   if (client.validateConnection()) {
@@ -103,24 +101,15 @@ void setup() {
   scale.begin(LOADCELL_DOUT_PIN, LOADCELL_SCK_PIN);
   Serial.println(CALIBRATION_FACTOR);
   scale.set_scale(CALIBRATION_FACTOR);   // this value is obtained by calibrating the scale with known weights; see the README for details
-  scale.tare();               // reset the scale to 0
+  Serial.println("Resetting the tare to 0 -- REMOVE ALL OBJECTS ");
+  delay(3000);
+  scale.tare(5);               // reset the scale to 0, measured 5 times to be sure
 }
 
 void loop() {
-  // If no Wifi signal, try to reconnect it
-
-  if (button.getSingleDebouncedPress()){
-    Serial.println("Tare reset to 0");
-    scale.tare();
-  }
-  
+  // If no Wifi signal, try to reconnect it  
   if (wifiMulti.run() != WL_CONNECTED) {
     Serial.println("Wifi connection lost");
-  }
-  
-  if (button.getSingleDebouncedPress()){
-    Serial.print("tare...");
-    scale.tare();
   }
   
   if (scale.wait_ready_timeout(200)) {


### PR DESCRIPTION
This will get a proper time sync from NTP servers, then start writing out the weight from the scale to InfluxDB using the DEVICE_NAME as a filter so be sure to set that to something unique in your config.h

Also cleaned up some error handling on the serial port.  